### PR TITLE
revert back to exporting module.id instead of template function

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -23,10 +23,10 @@ module.exports = class EmberHandlebarsCompiler
       tmplName = "module.id.replace('#{@root}','')"
       if @precompile is on
         content = compileHBS data.toString()
-        result  = "\nEmber.TEMPLATES['#{tmplName}'] = Ember.Handlebars.template(#{content});\n module.exports = '#{tmplName}';"
+        result  = "\nEmber.TEMPLATES[#{tmplName}] = Ember.Handlebars.template(#{content});\n module.exports = #{tmplName};"
       else
         content = JSON.stringify data.toString()
-        result  = "\nEmber.TEMPLATES['#{tmplName}'] = Ember.Handlebars.compile(#{content});\n module.exports = '#{tmplName}';"
+        result  = "\nEmber.TEMPLATES[#{tmplName}] = Ember.Handlebars.compile(#{content});\n module.exports = #{tmplName};"
     catch err
       error = err
     finally

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -20,13 +20,13 @@ module.exports = class EmberHandlebarsCompiler
 
   compile: (data, path, callback) ->
     try
-      tmplName = "Ember.TEMPLATES[module.id.replace('#{@root}','')]"
+      tmplName = "module.id.replace('#{@root}','')"
       if @precompile is on
         content = compileHBS data.toString()
-        result  = "module.exports = #{tmplName} = Ember.Handlebars.template(#{content});"
+        result  = "\nEmber.TEMPLATES['#{tmplName}'] = Ember.Handlebars.template(#{content});\n module.exports = '#{tmplName}';"
       else
         content = JSON.stringify data.toString()
-        result  = "module.exports = #{tmplName} = Ember.Handlebars.compile(#{content});"
+        result  = "\nEmber.TEMPLATES['#{tmplName}'] = Ember.Handlebars.compile(#{content});\n module.exports = '#{tmplName}';"
     catch err
       error = err
     finally


### PR DESCRIPTION
Not sure if you want to pull this change back into the repo, but after testing your newest changes with the latest ember.js build, the application breaks when trying to load templates.  The `templateForName` function within the `Ember.View` class expects a templateName string to lookup, rather than the template function itself.  This was causing a syntax error when trying to parse `name.indexOf('.')`.  Reverting to the old way of exporting the module.id (with `/templates` removed from the string) seemed to fix the issue.
